### PR TITLE
Fixed issue #3

### DIFF
--- a/tvrage/api.py
+++ b/tvrage/api.py
@@ -209,11 +209,12 @@ class Show(object):
     def latest_episode(self):
         """returns the latest episode that has aired already"""
         today = date.today()
-        eps = self.season(self.seasons).values()
-        eps.reverse()
-        for e in eps:
-            if (e.airdate is not None) and (e.airdate < today):
-                return e
+        for season_no in reversed(range(1,self.seasons+1)):
+            eps = self.season(season_no).values()
+            eps.reverse()
+            for e in eps:
+                if (e.airdate is not None) and (e.airdate < today):
+                    return e
 
     @property
     def synopsis(self):


### PR DESCRIPTION
Example demonstrated in issue is no longer present.

```
>>> import tvrage.api
>>> show = tvrage.api.Show('Community');
>>> show.latest_episode
Community 4x13 Advanced Introduction to Finality
```
